### PR TITLE
Cache System

### DIFF
--- a/Scrape.py
+++ b/Scrape.py
@@ -1,10 +1,37 @@
 import requests
 import concurrent.futures
 import time
+import os
+import json
+
+from datetime import datetime
+
+cache_dir = 'cache'
+user_cache_file = 'user_cache.json'
+group_cache_file = 'group_cache.json'
+
+
+def load_cache(cache_dir, filename):
+    file_path = os.path.join(cache_dir, filename)
+    try:
+        with open(file_path, 'r') as file:
+            return set(json.load(file))
+    except FileNotFoundError:
+        return set()
+
+def save_cache(cache_dir, filename, cache_set):
+    if not os.path.exists(cache_dir):
+        os.makedirs(cache_dir)
+    file_path = os.path.join(cache_dir, filename)
+    with open(file_path, 'w') as file:
+        json.dump(list(cache_set), file)
+
+processed_users = load_cache(cache_dir, user_cache_file)
+processed_groups = load_cache(cache_dir, group_cache_file)
 
 group_ids = [8923350, 11891341, 17150723]  # Replace with your desired group IDs
 
-def get_group_members(group_id):
+def get_group_members(group_id, processed_users, cache_dir, user_cache_file):
       user_ids = set()
       cursor = None
       while True:
@@ -13,16 +40,21 @@ def get_group_members(group_id):
           response = requests.get(url, params=params)
           if response.status_code == 200:
               data = response.json()
-              user_ids.update(member['user']['userId'] for member in data['data'])
+              new_users = [member['user']['userId'] for member in data['data'] if member['user']['userId'] not in processed_users]
+              user_ids.update(new_users)
               cursor = data.get("nextPageCursor")
               if not cursor:
                   break
           else:
               # Handle errors or rate limiting here
               break
+      processed_users.update(user_ids)
+      save_cache(cache_dir, user_cache_file, processed_users)
       return user_ids
 
-def get_user_groups(user_id):
+def get_user_groups(user_id, processed_users, cache_dir, user_cache_file):
+      if user_id in processed_users:
+          return []
       group_ids = []
       try:
           response = requests.get(f"https://groups.roblox.com/v1/users/{user_id}/groups/roles")
@@ -32,6 +64,8 @@ def get_user_groups(user_id):
       except Exception as e:
           # Handle exceptions appropriately
           pass
+      processed_users.add(user_id)
+      save_cache(cache_dir, user_cache_file, processed_users)
       return group_ids
 
 def count_group_ids(members_groups, exclude_group_ids):
@@ -45,7 +79,7 @@ def count_group_ids(members_groups, exclude_group_ids):
 all_members = set()
 for group_id in group_ids:
       print(f"Collecting members from group {group_id}...")
-      members = get_group_members(group_id)
+      members = get_group_members(group_id, processed_groups, cache_dir, group_cache_file)
       all_members.update(members)
       print(f"Collected {len(members)} members from group {group_id}. Total unique members so far: {len(all_members)}")
 
@@ -56,7 +90,7 @@ members_processed = 0
 members_groups = []
 
 with concurrent.futures.ThreadPoolExecutor() as executor:
-      futures = {executor.submit(get_user_groups, user_id): user_id for user_id in all_members}
+      futures = {executor.submit(get_user_groups, user_id, processed_users, cache_dir, user_cache_file): user_id for user_id in all_members}
       for future in concurrent.futures.as_completed(futures):
           members_groups.append(future.result())
           members_processed += 1
@@ -72,4 +106,16 @@ with open('group_counts_output.txt', 'w') as outfile:
       for gid, count in group_counts:
           outfile.write(f"https://www.roblox.com/groups/{gid}/x - {count}\n")
 
-print("Processing complete. Results saved to group_counts_output.txt")
+outputs_dir = 'outputs'
+if not os.path.exists(outputs_dir):
+      os.makedirs(outputs_dir)
+
+current_time = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+filename = f"group_counts_output_{current_time}.txt"
+file_path = os.path.join(outputs_dir, filename)
+
+with open(file_path, 'w') as outfile:
+      for gid, count in group_counts:
+          outfile.write(f"https://www.roblox.com/groups/{gid}/x - {count}\n")
+
+print(f"Processing complete. Results saved to {file_path}")


### PR DESCRIPTION
Creates a simple cache system to make processing faster. To reset simply delete the cache folder. This makes adding new groups at a rapid pace faster because it wont have to go through the same users again. New users who join groups since the cache will still be counted and collected.